### PR TITLE
feat: add keyboard event queue buffering

### DIFF
--- a/SOURCE/KERNEL/32RTOSKRNL/DRIVERS/PS2/KEYBOARD_MOUSE.c
+++ b/SOURCE/KERNEL/32RTOSKRNL/DRIVERS/PS2/KEYBOARD_MOUSE.c
@@ -36,6 +36,13 @@ VOID UPDATE_KP_MOUSE_DATA(void) {
         g_input.kb.cur.ASCII = KEYPRESS_TO_CHARS(g_input.kb.cur.keycode);
         g_input.kb.seq++;
         g_input.kb_event = TRUE;
+
+        U8 next_tail = (g_input.kb.queue_tail + 1) % KB_EVENT_QUEUE_SIZE;
+        if (next_tail != g_input.kb.queue_head) {
+            g_input.kb.event_queue[g_input.kb.queue_tail].key = ev.key;
+            g_input.kb.event_queue[g_input.kb.queue_tail].mods = g_input.kb.mods;
+            g_input.kb.queue_tail = next_tail;
+        }
     }
 
     else if (ev.type == PS2_EVT_MOUSE) {

--- a/SOURCE/KERNEL/32RTOSKRNL/DRIVERS/PS2/KEYBOARD_MOUSE.h
+++ b/SOURCE/KERNEL/32RTOSKRNL/DRIVERS/PS2/KEYBOARD_MOUSE.h
@@ -652,11 +652,22 @@ typedef struct _MOUSE_DATA{
     U32 scroll_wheel;
 } MOUSE_DATA;
 
+#define KB_EVENT_QUEUE_SIZE 32
+
+typedef struct _KB_EVENT {
+    KEYPRESS key;
+    MODIFIERS mods;
+} KB_EVENT;
+
 typedef struct _PS2_KB_DATA{
     KEYPRESS cur;
     KEYPRESS prev;
     MODIFIERS mods;
     U32 seq; // incremented by kernel on every new keypress. if prev_seq != seq, new keypress has happened
+
+    KB_EVENT event_queue[KB_EVENT_QUEUE_SIZE];
+    volatile U8 queue_head;
+    volatile U8 queue_tail;
 } PS2_KB_DATA;
 
 typedef struct _PS2_MOUSE_DATA{

--- a/SOURCE/PROGRAMS/SYS_PROGS/TSHELL/TOUTPUT.c
+++ b/SOURCE/PROGRAMS/SYS_PROGS/TSHELL/TOUTPUT.c
@@ -145,13 +145,12 @@ static VOID render_visible(VOID) {
     /* Clamp so we don't go negative */
     I32 bottom_sb = (I32)tout->scrollback.write_row - (I32)offset;
 
-    /* Move window cursor to (0,0) and redraw full screen */
-    ATUI_WMOVE(win, 0, 0);
-
     /* Cursor overlay coordinates (prompt_row in scrollback, column) */
     U32 cur_sb_row = tout->prompt_row;
     U32 cur_col    = tout->prompt_length + tout->edit_pos;
     if (cur_col >= vis_cols) cur_col = vis_cols - 1;
+
+    BOOL any_change = FALSE;
 
     for (U32 vr = 0; vr < vis_rows; vr++) {
         I32 sb_idx = bottom_sb - (I32)(vis_rows - 1) + (I32)vr;
@@ -162,6 +161,7 @@ static VOID render_visible(VOID) {
 
         for (U32 vc = 0; vc < vis_cols; vc++) {
             SCROLLBACK_CELL *cell = &tout->scrollback.cells[sb_idx][vc];
+            SCROLLBACK_CELL *last = &tout->scrollback.last_render[vr][vc];
             VBE_COLOUR fg = cell->fg;
             VBE_COLOUR bg = cell->bg;
 
@@ -190,13 +190,24 @@ static VOID render_visible(VOID) {
                 bg = tmp;
             }
 
-            ATUI_WSET_COLOR(win, fg, bg);
-            ATUI_WMOVE(win, vr, vc);
-            ATUI_WADDCH(win, cell->c);
+            /* Only update cells that actually changed */
+            if (last->c != cell->c || last->fg != fg || last->bg != bg) {
+                ATUI_WSET_COLOR(win, fg, bg);
+                ATUI_WMOVE(win, vr, vc);
+                ATUI_WADDCH(win, cell->c);
+                any_change = TRUE;
+            }
+
+            /* Remember what we actually rendered (with overlay applied) */
+            last->c  = cell->c;
+            last->fg = fg;
+            last->bg = bg;
         }
     }
 
-    ATUI_WREFRESH(win);
+    if (any_change) {
+        ATUI_WREFRESH(win);
+    }
 }
 
 /* ================================================================== */

--- a/SOURCE/STD/IO.c
+++ b/SOURCE/STD/IO.c
@@ -94,6 +94,17 @@ PS2_KB_DATA *kb_poll(void) {
 
     volatile PS2_KB_DATA *kb = &input.shared->kb;
 
+    if (kb->queue_head != kb->queue_tail) {
+        static PS2_KB_DATA result ATTRIB_DATA;
+        U8 head = kb->queue_head;
+        result.cur = kb->event_queue[head].key;
+        result.mods = kb->event_queue[head].mods;
+        result.seq = kb->seq;
+        kb->queue_head = (head + 1) % KB_EVENT_QUEUE_SIZE;
+        input.last_kb_seq = kb->seq;
+        return &result;
+    }
+
     if (kb->seq != input.last_kb_seq) {
         input.last_kb_seq = kb->seq;
         return (PS2_KB_DATA *)&kb->cur;
@@ -103,7 +114,19 @@ PS2_KB_DATA *kb_poll(void) {
 
 PS2_KB_DATA *kb_peek(void) {
     if (!input.shared) return NULLPTR;
-    return &input.shared->kb.cur;
+
+    volatile PS2_KB_DATA *kb = &input.shared->kb;
+
+    if (kb->queue_head != kb->queue_tail) {
+        static PS2_KB_DATA result ATTRIB_DATA;
+        U8 head = kb->queue_head;
+        result.cur = kb->event_queue[head].key;
+        result.mods = kb->event_queue[head].mods;
+        result.seq = kb->seq;
+        return &result;
+    }
+
+    return (PS2_KB_DATA *)&kb->cur;
 }
 
 PS2_KB_DATA *kb_last(void) {


### PR DESCRIPTION
Implement a ring buffer queue for keyboard events to prevent losing key presses during high-frequency input. Add KB_EVENT structure to store key and modifier state. Update kb_poll() and kb_peek() to read from queue. Optimize terminal rendering by only updating changed cells and deferring refresh when no changes occur.